### PR TITLE
Extracted the common code of cassandra and memcached server image creation to cloudsuite/commons which is extended by specific applications like data-caching, data-serving and django-workload

### DIFF
--- a/benchmarks/data-caching/server/Dockerfile
+++ b/benchmarks/data-caching/server/Dockerfile
@@ -1,38 +1,8 @@
-FROM ubuntu:16.04
-MAINTAINER Arash Pourhabibi Zarandi <arash.pourhabibi@epfl.ch>
-
-# This is based on the official memcached Dockerfile
-
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r memcache && useradd -r -g memcache memcache
-
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		libevent-2.0-5 \
-	&& rm -rf /var/lib/apt/lists/*
-
-ENV MEMCACHED_VERSION 1.4.24
-ENV MEMCACHED_SHA1 32a798a37ef782da10a09d74aa1e5be91f2861db
-
-RUN buildDeps='curl gcc libc6-dev libevent-dev make perl' \
-	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& curl -SL "http://memcached.org/files/memcached-$MEMCACHED_VERSION.tar.gz" -o memcached.tar.gz \
-	&& echo "$MEMCACHED_SHA1 memcached.tar.gz" | sha1sum -c - \
-	&& mkdir -p /usr/src/memcached \
-	&& tar -xzf memcached.tar.gz -C /usr/src/memcached --strip-components=1 \
-	&& rm memcached.tar.gz \
-	&& cd /usr/src/memcached \
-	&& ./configure \
-	&& make \
-	&& make install \
-	&& cd / && rm -rf /usr/src/memcached \
-	&& apt-get purge -y --auto-remove $buildDeps
+FROM cloudsuite/memcached
 
 ENTRYPOINT ["memcached"]
 
 USER memcache
 EXPOSE 11211
 CMD ["-t", "2", "-m", "2048", "-n", "550"]
+

--- a/benchmarks/data-serving/client/Dockerfile
+++ b/benchmarks/data-serving/client/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update \
  && apt-get autoremove && apt-get clean && apt-get upgrade -y \
  && groupadd -r cassandra && useradd -r -g cassandra cassandra
 
-RUN wget -q https://github.com/brianfrankcooper/YCSB/releases/download/0.3.0/ycsb-0.3.0.tar.gz -O /ycsb-0.3.0.tar.gz \
- && tar -xzf /ycsb-0.3.0.tar.gz && rm /ycsb-0.3.0.tar.gz && mv /ycsb-0.3.0 /ycsb \
+RUN wget -q https://github.com/brianfrankcooper/YCSB/releases/download/0.13.0/ycsb-0.13.0.tar.gz -O /ycsb-0.13.0.tar.gz \
+ && tar -xzf /ycsb-0.13.0.tar.gz && rm /ycsb-0.13.0.tar.gz && mv /ycsb-0.13.0 /ycsb \
  && chown cassandra:cassandra -R /ycsb/workloads
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/benchmarks/data-serving/client/docker-entrypoint.sh
+++ b/benchmarks/data-serving/client/docker-entrypoint.sh
@@ -11,6 +11,6 @@ if [ ! -z "$OPERATIONCOUNT" ]; then
     OPERATIONCOUNT="-p operationcount=$OPERATIONCOUNT"
 fi
 
-/ycsb/bin/ycsb load cassandra-10 -p hosts=$1 -P /ycsb/workloads/workloada $RECORDCOUNT > /dev/null
+/ycsb/bin/ycsb load cassandra-cql -p hosts=$1 -P /ycsb/workloads/workloada $RECORDCOUNT > /dev/null
 
-/ycsb/bin/ycsb run cassandra-10 -p hosts=$1 -P /ycsb/workloads/workloada $OPERATIONCOUNT
+/ycsb/bin/ycsb run cassandra-cql -p hosts=$1 -P /ycsb/workloads/workloada $OPERATIONCOUNT

--- a/benchmarks/data-serving/server/Dockerfile
+++ b/benchmarks/data-serving/server/Dockerfile
@@ -1,22 +1,8 @@
-FROM ubuntu:14.04
+FROM cloudsuite/cassandra
 
-ENV CASSANDRA_VERSION 2.1.12
 
-ENV CASSANDRA_CONFIG /etc/cassandra
+COPY files/* /scripts/
 
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 514A2AD631A57A16DD0047EC749D6EEC0353B12C A278B781FE4B2BDA\
-	&& echo 'deb http://www.apache.org/dist/cassandra/debian 21x main' >> /etc/apt/sources.list.d/cassandra.list \
-	&& apt-get update \
-    	&& apt-get install -y cassandra \
-    	&& rm -rf /var/lib/apt/lists/*
 
-# https://issues.apache.org/jira/browse/CASSANDRA-11661
-RUN sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' /etc/cassandra/cassandra-env.sh
+ENTRYPOINT ["/scripts/bootstrap.sh"]
 
-COPY setup_tables.txt /setup_tables.txt
-COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
-CMD ["cassandra"]
-ENTRYPOINT ["/docker-entrypoint.sh"]
-
-EXPOSE 7000 7001 7199 9042 9160

--- a/benchmarks/data-serving/server/files/bootstrap.sh
+++ b/benchmarks/data-serving/server/files/bootstrap.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+chmod +x /scripts/dataserving_config.sh
+/scripts/dataserving_config.sh cassandra
+

--- a/benchmarks/data-serving/server/files/setup_tables.txt
+++ b/benchmarks/data-serving/server/files/setup_tables.txt
@@ -1,0 +1,15 @@
+CREATE KEYSPACE ycsb
+        WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 3 };
+USE ycsb;
+CREATE TABLE usertable (
+    y_id varchar primary key,
+    field0 varchar,
+    field1 varchar,
+    field2 varchar,
+    field3 varchar,
+    field4 varchar,
+    field5 varchar,
+    field6 varchar,
+    field7 varchar,
+    field8 varchar,
+    field9 varchar);

--- a/benchmarks/data-serving/server/setup_tables.txt
+++ b/benchmarks/data-serving/server/setup_tables.txt
@@ -1,4 +1,0 @@
-create keyspace usertable;
-use usertable;
-create column family data;
-exit;

--- a/commons/cassandra/Dockerfile
+++ b/commons/cassandra/Dockerfile
@@ -1,0 +1,29 @@
+FROM cloudsuite/java
+
+ENV DEBIAN_FRONTEND noninteractive
+#ENV http_proxy http://proxy-address:proxy-port
+#ENV https_proxy https://proxy-address:proxy-port
+
+ENV CASSANDRA_CONFIG /etc/cassandra
+
+RUN apt-get update                                                                     \
+    && mkdir /scripts                                                                  \
+    && apt-get install -y curl                                                         \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0xC2518248EEA14886 \
+    && curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -                 \
+    && echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"         \
+        > /etc/apt/sources.list.d/webupd8team-ubuntu-java-xenial.list                  \
+    && echo "deb http://www.apache.org/dist/cassandra/debian 30x main"                 \
+        > /etc/apt/sources.list.d/cassandra.list                                       \
+    && apt-get update                                                                  \
+    && apt-get install -y cassandra
+
+
+
+RUN echo "Add limits settings ...\n"\
+    && echo "* soft nofile 1000000" >> /etc/security/limits.conf \
+    && echo "* hard nofile 1000000" >> /etc/security/limits.conf
+
+
+ENV DEBIAN_FRONTEND teletype
+

--- a/commons/memcached/Dockerfile
+++ b/commons/memcached/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:16.04
+MAINTAINER Arash Pourhabibi Zarandi <arash.pourhabibi@epfl.ch>
+
+# This is based on the official memcached Dockerfile
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r memcache && useradd -r -g memcache memcache
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+                libevent-2.0-5 \
+        && rm -rf /var/lib/apt/lists/*
+
+ENV MEMCACHED_VERSION 1.4.24
+ENV MEMCACHED_SHA1 32a798a37ef782da10a09d74aa1e5be91f2861db
+
+RUN buildDeps='curl gcc libc6-dev libevent-dev make perl' \
+        && set -x \
+        && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+        && rm -rf /var/lib/apt/lists/* \
+        && curl -SL "http://memcached.org/files/memcached-$MEMCACHED_VERSION.tar.gz" -o memcached.tar.gz \
+        && echo "$MEMCACHED_SHA1 memcached.tar.gz" | sha1sum -c - \
+        && mkdir -p /usr/src/memcached \
+        && tar -xzf memcached.tar.gz -C /usr/src/memcached --strip-components=1 \
+        && rm memcached.tar.gz \
+        && cd /usr/src/memcached \
+        && ./configure \
+        && make \
+        && make install \
+        && cd / && rm -rf /usr/src/memcached \
+        && apt-get purge -y --auto-remove $buildDeps
+
+


### PR DESCRIPTION
**Changes**:
1. Base image creation code for Cassandra and Memcached servers is moved to _cloudsuite/commons._ These base images are used by the _data-caching, data-serving and django-worklaod_ applications to create their specific server images.
2. Updated Cassandra Server to _v3.0.x_ (from v2.1.x) and Cassandra Client to _v0.13.0_ (from v0.3.0)
3. No updates in Memcached Server/Client versions.

**Steps to create Cassandra server image for the data-serving application:**
1. First, create cassandra base image as follows by navigating to cloudsuite/commons/cassandra directory and run
	`$	docker build . --tag cloudsuite/cassandra`
2. Now, navigate to cloudsuite/benchmarks/data-serving directory to build data-serving specific cassandra server image
	`$	docker build . --tag cloudsuite/data-serving:server`
3. Once you build the cloudsuite/data-serving:server image, follow the exisiting documentation(http://cloudsuite.ch//pages/benchmarks/dataserving/) to run the cassandra server as a docker container.

**Steps to create Memcached server image for the data-caching application:**
1. First, create memcached base image as follows by navigating to cloudsuite/commons/memcached directory and run
	`$	docker build . --tag cloudsuite/memcached`
2. Now, navigate to cloudsuite/benchmarks/data-caching directory to build data-caching specific memcached server image
	`$	docker build . --tag cloudsuite/data-caching:server`
3. Once you build the cloudsuite/data-caching:server image, follow the exisiting documentation(http://cloudsuite.ch//pages/benchmarks/datacaching/) to run the memcached server as a docker container.